### PR TITLE
CMakeList: Fix conflict of protobuf package between system's and internal's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,12 @@ endmacro ()
 
 set(protobuf_BUILD_TESTS OFF)
 set(protobuf_BUILD_EXAMPLES OFF)
-add_subdirectory (thirdparty/protobuf/cmake)
+
+find_package(Protobuf)
+if (NOT PROTOBUF_FOUND)
+    add_subdirectory (thirdparty/protobuf/cmake)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/protobuf/cmake")
+endif ()
 
 enable_testing ()
 

--- a/retrace/daemon/CMakeLists.txt
+++ b/retrace/daemon/CMakeLists.txt
@@ -2,6 +2,10 @@ include(Lint.cmake)
 
 include(FindProtobuf)
 
+if (NOT PROTOBUF_FOUND)
+  find_package(Protobuf, REQUIRED)
+endif ()
+
 if (WIN32)
 set (Protobuf_PROTOC_EXECUTABLE protoc)
 else()
@@ -94,7 +98,7 @@ add_library(retrace_daemon STATIC
 target_link_libraries(retrace_daemon
   glretrace_common
   retrace_gldispatch
-  libprotobuf
+  ${PROTOBUF_LIBRARIES}
   )
 
 add_dependencies(retrace_daemon protoc)

--- a/retrace/daemon/bargraph/test/CMakeLists.txt
+++ b/retrace/daemon/bargraph/test/CMakeLists.txt
@@ -29,12 +29,11 @@ add_library(retrace_ui_test_utilities
   ${TEST_UTILITIES_SOURCE}
   )
 
-
 target_link_libraries(retrace_bargraph_test
   retrace_ui_test_utilities
   retrace_bargraph
   retrace_gldispatch
-  libprotobuf
+  ${PROTOBUF_LIBRARIES}
   gtest
   waffle-1
   Qt5::Core

--- a/retrace/daemon/server/CMakeLists.txt
+++ b/retrace/daemon/server/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(frameretrace_server
   glretrace_common
   glhelpers
   glproc_gl
-  libprotobuf
+  ${PROTOBUF_LIBRARIES}
   ${GL_LIB}
   ${X11_X11_LIB}
   ${THREAD_LIB}

--- a/retrace/daemon/test/CMakeLists.txt
+++ b/retrace/daemon/test/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(retrace_daemon_test
   retrace_gldispatch
   glhelpers
   glproc_gl
-  libprotobuf
+  ${PROTOBUF_LIBRARIES}
   gtest
   ${DAEMON_TEST_OS_LIBS}
   )

--- a/retrace/daemon/ui/CMakeLists.txt
+++ b/retrace/daemon/ui/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries(frameretrace
   glhelpers
   glproc_gl
   Qt5::Core Qt5::Gui Qt5::Concurrent Qt5::Quick Qt5::Widgets
-  libprotobuf
+  ${PROTOBUF_LIBRARIES}
   ${GL_LIB}
   ${X11_X11_LIB}
   ${THREAD_LIB}


### PR DESCRIPTION
CMakeList: if Protobuf package is available on system, then use system's Protobuf.
                  if not avaiable, then build and link against internal Protobuf package.
