### PR TITLE
Compatibility with Qt 5.7

### DIFF
--- a/retrace/daemon/ui/qml/ComboBoxFitContents.qml
+++ b/retrace/daemon/ui/qml/ComboBoxFitContents.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.7
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.0
 
 // based on
 // https://stackoverflow.com/questions/45029968/how-do-i-set-the-combobox-width-to-fit-the-largest-item


### PR DESCRIPTION
QtQuick.Controls 2.2 exists in Qt 5.9 and above, whereas QtQuick.Controls 2.0 works in Qt 5.7
The code otherwise works as is with Qt 5.7. Tested with Debian stretch & backported Mesa 17.3.6 & Linux Kernel 4.14.