### PR TITLE
Fix crash in FrameRetraceStub::Shutdown(..)

### DIFF
--- a/retrace/daemon/glframe_retrace_stub.cpp
+++ b/retrace/daemon/glframe_retrace_stub.cpp
@@ -1134,7 +1134,9 @@ FrameRetraceStub::Init(const char *host, int port) {
 
 void
 FrameRetraceStub::Shutdown() {
-  assert(m_thread != NULL);
+  if (!m_thread)
+    return;
+
   m_thread->stop();
   delete m_thread;
 }


### PR DESCRIPTION
If frameretrace gets stared and closed without doing any analysis
a segfault gets triggered.

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>